### PR TITLE
add: Public/Private Subnets at least 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 [![codecov](https://codecov.io/gh/otajisan/morningcode-basic-cdk/branch/main/graph/badge.svg?token=4O12EDLC9A)](https://codecov.io/gh/otajisan/morningcode-basic-cdk)
 
 ```bash
-npx cdk diff --profile morning-code-dev BackEndStack
-npx cdk deploy --profile morning-code-dev BackEndStack
+npx cdk diff --profile morning-code-dev MorningcodeBasicCdkStack
+npx cdk deploy --profile morning-code-dev MorningcodeBasicCdkStack
 ```

--- a/lib/morningcode-basic-cdk-stack.ts
+++ b/lib/morningcode-basic-cdk-stack.ts
@@ -1,5 +1,5 @@
-import { Stack, StackProps, Tags } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
+import {Stack, StackProps, Tags} from 'aws-cdk-lib';
+import {Construct} from 'constructs';
 import {
   CfnEIP,
   CfnInternetGateway,
@@ -28,11 +28,11 @@ export class MorningcodeBasicCdkStack extends Stack {
       cidrBlock: '192.168.0.0/24',
     });
 
-    // const publicSubnet2 = new Subnet(this, 'PublicSubnet1c', {
-    //   availabilityZone: 'ap-northeast-1c',
-    //   vpcId: vpc.vpcId,
-    //   cidrBlock: '192.168.1.0/24',
-    // });
+    const publicSubnet2 = new Subnet(this, 'PublicSubnet1c', {
+      availabilityZone: 'ap-northeast-1c',
+      vpcId: vpc.vpcId,
+      cidrBlock: '192.168.1.0/24',
+    });
 
     // Private Subnets
     const privateSubnet1 = new Subnet(this, 'PrivateSubnet1a', {
@@ -41,11 +41,11 @@ export class MorningcodeBasicCdkStack extends Stack {
       cidrBlock: '192.168.10.0/24',
     });
 
-    // const privateSubnet2 = new Subnet(this, 'PrivateSubnet1c', {
-    //   availabilityZone: 'ap-northeast-1c',
-    //   vpcId: vpc.vpcId,
-    //   cidrBlock: '192.168.11.0/24',
-    // });
+    const privateSubnet2 = new Subnet(this, 'PrivateSubnet1c', {
+      availabilityZone: 'ap-northeast-1c',
+      vpcId: vpc.vpcId,
+      cidrBlock: '192.168.11.0/24',
+    });
 
     // Internet Gateway
     const internetGateway = new CfnInternetGateway(this, 'InternetGateway', {});
@@ -62,10 +62,10 @@ export class MorningcodeBasicCdkStack extends Stack {
       routerId: internetGateway.ref,
     });
 
-    // publicSubnet2.addRoute('PublicSubnetRoute', {
-    //   routerType: RouterType.GATEWAY,
-    //   routerId: internetGateway.ref,
-    // });
+    publicSubnet2.addRoute('PublicSubnetRoute', {
+      routerType: RouterType.GATEWAY,
+      routerId: internetGateway.ref,
+    });
 
     // EIP for NAT Gateway
     const eip1 = new CfnEIP(this, 'ElasticIP1', {});

--- a/test/morningcode-basic-cdk.test.ts
+++ b/test/morningcode-basic-cdk.test.ts
@@ -43,7 +43,7 @@ describe('correct resources are created', () => {
   test('Subnets are created', () => {
     const template = Template.fromStack(synthStack());
 
-    template.resourceCountIs('AWS::EC2::Subnet', 2);
+    template.resourceCountIs('AWS::EC2::Subnet', 4);
     template.hasResourceProperties('AWS::EC2::Subnet', {
       VpcId: { Ref: vpcId },
       AvailabilityZone: 'ap-northeast-1a',


### PR DESCRIPTION
- 該当VPCにECS Taskをぶら下げようとしたところ、CDKで以下のエラー
```bash
Stack Deployments Failed: Error: The stack named IngressGatewayServiceStack failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: At least two subnets in two different Availability Zones must be specified (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: ValidationError; Request ID: xxx-xxx-4ad2-xxx-xxx; Proxy: null)
```
- 少なくとも2つのAvailability Zone分のSubnetが必要、とのことで、有効化した